### PR TITLE
Missing results in search bar

### DIFF
--- a/src/menu/search_index.ts
+++ b/src/menu/search_index.ts
@@ -96,7 +96,7 @@ class LunrSearchIndex implements SearchIndex {
     const query = input
       .split(' ')
       .filter((s) => !!s)
-      .map((s) => `+${s}*`)
+      .map((s) => `${s} ${s}*`)
       .join(' ');
     const results = this.index!.search(query);
     return results


### PR DESCRIPTION
I've noticed that search bar doesn't work correctly. Many times when I type full names I've got no results.

The easiest way to reproduce:

1. Open [Shakespeare's example tree](https://pewu.github.io/topola-viewer/#/view?url=https%3A%2F%2Fwebtreeprint.com%2Ftp_downloader.php%3Fpath%3Dfamous_gedcoms%2Fshakespeare.ged)
2. Type `Shakespeare` in search bar. 
3. No results found
![no_results](https://user-images.githubusercontent.com/15907129/147390303-39f97bf8-8cfe-4094-8190-9d465f57850e.png)

I analyzed the problem and it seems in `lunr.js` stemmer and wildcards doesn't work together. So in my example word `Shakespeare` is stemmed to `Shakesp` and I will get no results for phrases longer than stemmed version of the word. 

[From lunr.js docs:](https://lunrjs.com/guides/searching.html#wildcards)
>It is also worth noting that, when a search term contains a wildcard, no stemming is performed on the search term.


As a workaround I propose search by both wildcard and exact phrase. It works with a small drawback. 

Before fix, all words from phrase were mandatory. Now its no longer possible and when I type for example `William Shakespeare` I will see results for both words, so all persons named `William` and all persons named  `Shakespeare`. Although `William Shakespeare` will be top result, so I think it's acceptable.
