### PR TITLE
Moving elements when scrollbar apperas (Firefox only)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,7 @@ body, html {
   flex: 1 1 auto;
   display: flex;
   overflow: hidden;
+  height: 100%;
 }
 
 #svgContainer {


### PR DESCRIPTION

Fix for annoying bug in Firefox.
When chart is zoomed-in and scrollbar appears/disappears, some elements in navigation panel and in details panel are moving.

![scroll_bug](https://user-images.githubusercontent.com/15907129/148274343-848d0978-7aa5-42d4-9469-3c77be99df23.gif)

