### PR TITLE
Fix age calculation, when lifespan contains years divisible by 100 and not by 400

### DIFF
--- a/src/util/age_util.spec.ts
+++ b/src/util/age_util.spec.ts
@@ -32,6 +32,18 @@ describe('calcAge()', () => {
     const age = calcAge('2 Sep 1990', '1 Sep 2021', intl);
     expect(age).toEqual('30 years');
   });
+  it('age respecting missing leap year divisible by 100 and not divisible by 400', () => {
+    const age = calcAge('1890', '1921', intl);
+    expect(age).toEqual('31 years');
+  });
+  it('age respecting missing leap year divisible by 100 and not divisible by 400 for full dates', () => {
+    const age = calcAge('1 Sep 1890', '1 Sep 1921', intl);
+    expect(age).toEqual('31 years');
+  });
+  it('age with round down respecting missing leap year divisible by 100 and not divisible by 400', () => {
+    const age = calcAge('2 Sep 1890', '1 Sep 1921', intl);
+    expect(age).toEqual('30 years');
+  });
 
   it('age with exact and range between', () => {
     const age = calcAge('1990', 'BET 2020 AND 2021', intl);

--- a/src/util/age_util.ts
+++ b/src/util/age_util.ts
@@ -115,10 +115,21 @@ function calcDateDifferenceInYears(
   const firstDateObject = toDateObject(firstDate);
   const secondDateObject = toDateObject(secondDate);
 
-  const dateDiff = new Date(
-    secondDateObject.valueOf() - firstDateObject.valueOf(),
-  );
-  return Math.abs(dateDiff.getUTCFullYear() - 1970);
+  const startYear = firstDateObject.getUTCFullYear();
+
+  let yearDiff = secondDateObject.getUTCFullYear() - startYear;
+  let monthDiff = secondDateObject.getUTCMonth() - firstDateObject.getUTCMonth();
+  if (monthDiff < 0) {
+    yearDiff--;
+    monthDiff += 12;
+  }
+  const dayDiff = secondDateObject.getUTCDate() - firstDateObject.getUTCDate();
+  if (dayDiff < 0) {
+    if (monthDiff <= 0) {
+      yearDiff--;
+    }
+  }
+  return Math.abs(yearDiff);
 }
 
 export function calcAge(


### PR DESCRIPTION
Rewrite of calcDateDifferenceInYears function, because of invalid result for person with lifespan containing years divisible by 100 and not by 400. So for anyone born in XIX century who died in XX century, age was off by 1 year, unless full dates were used.

I covered this border case in unit tests. 