### PR TITLE
Fixed dateRanges when importing from wikitree

### DIFF
--- a/src/datasource/wikitree.ts
+++ b/src/datasource/wikitree.ts
@@ -13,6 +13,7 @@ import {GedcomData, normalizeGedcom, TopolaData} from '../util/gedcom_util';
 import {GedcomEntry} from 'parse-gedcom';
 import {IntlShape} from 'react-intl';
 import {TopolaError} from '../util/error';
+import {isValidDateOrRange} from '../util/date_util';
 
 /** Prefix for IDs of private individuals. */
 export const PRIVATE_ID_PREFIX = '~Private';
@@ -567,7 +568,7 @@ function dateOrRangeToGedcom(dateOrRange: DateOrRange): string {
 
 function eventToGedcom(event: JsonEvent): GedcomEntry[] {
   const result = [];
-  if (event.date) {
+  if (isValidDateOrRange(event)) {
     result.push({
       level: 2,
       pointer: '',


### PR DESCRIPTION
Fix for missing date ranges in details panel when importing data from wikitree api

[Example where date of death is visible on chart, but it's missing on details panel](https://pewu.github.io/topola-viewer/#/view?gen=3&indi=Splettst%C3%B6sser-4&source=wikitree&standalone=true ) 
