### PR TITLE
Display photos in details panel

### DIFF
--- a/src/details/details.tsx
+++ b/src/details/details.tsx
@@ -1,10 +1,17 @@
 import flatMap from 'array.prototype.flatmap';
-import {dereference, GedcomData, getData} from '../util/gedcom_util';
+import {
+  dereference,
+  GedcomData,
+  getData,
+  getFileName,
+  isImageFile,
+} from '../util/gedcom_util';
 import {Events} from './events';
 import {GedcomEntry} from 'parse-gedcom';
 import {MultilineText} from './multiline-text';
 import {TranslatedTag} from './translated-tag';
 import {Header, Item} from 'semantic-ui-react';
+import {WrappedImage} from './wrapped-image';
 
 const EXCLUDED_TAGS = [
   'BIRT',
@@ -45,6 +52,22 @@ function dataDetails(entry: GedcomEntry) {
       </span>
     </>
   );
+}
+
+function fileDetails(objectEntry: GedcomEntry) {
+  const imageFileEntry = objectEntry.tree.find(
+    (entry) =>
+      entry.tag === 'FILE' &&
+      entry.data.startsWith('http') &&
+      isImageFile(entry.data),
+  );
+
+  return imageFileEntry ? (
+    <WrappedImage
+      url={imageFileEntry.data}
+      filename={getFileName(imageFileEntry) || ''}
+    />
+  ) : null;
 }
 
 function noteDetails(entry: GedcomEntry) {
@@ -128,6 +151,7 @@ export function Details(props: Props) {
     <div className="details">
       <Item.Group divided>
         {getDetails(entries, ['NAME'], nameDetails)}
+        {getDetails(entriesWithData, ['OBJE'], fileDetails)}
         <Events gedcom={props.gedcom} entries={entries} indi={props.indi} />
         {getOtherDetails(entriesWithData)}
         {getDetails(entriesWithData, ['NOTE'], noteDetails)}

--- a/src/details/details.tsx
+++ b/src/details/details.tsx
@@ -63,10 +63,12 @@ function fileDetails(objectEntry: GedcomEntry) {
   );
 
   return imageFileEntry ? (
-    <WrappedImage
-      url={imageFileEntry.data}
-      filename={getFileName(imageFileEntry) || ''}
-    />
+    <div className="person-image">
+      <WrappedImage
+        url={imageFileEntry.data}
+        filename={getFileName(imageFileEntry) || ''}
+      />
+    </div>
   ) : null;
 }
 

--- a/src/details/wrapped-image.tsx
+++ b/src/details/wrapped-image.tsx
@@ -1,0 +1,51 @@
+import {Icon, Image, Label, Modal, Placeholder} from 'semantic-ui-react';
+import {useState} from 'react';
+
+interface Props {
+  url: string;
+  filename: string;
+  title?: string;
+}
+
+export function WrappedImage(props: Props) {
+  const [imageOpen, setImageOpen] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  return (
+    <>
+      <Image
+        className={imageLoaded ? 'loaded-image-thumbnail' : 'hidden-image'}
+        onClick={() => setImageOpen(true)}
+        onLoad={() => setImageLoaded(true)}
+        src={props.url}
+        alt={props.title || props.filename}
+        centered={true}
+      />
+      <Placeholder
+        className={!imageLoaded ? 'image-placeholder' : 'hidden-image'}
+      >
+        <Placeholder.Image square />
+      </Placeholder>
+      <Modal
+        basic
+        size="large"
+        closeIcon={<Icon name="close" color="red" />}
+        open={imageOpen}
+        onClose={() => setImageOpen(false)}
+        onOpen={() => setImageOpen(true)}
+        centered={false}
+      >
+        <Modal.Header className="center">{props.title}</Modal.Header>
+        <Modal.Content image>
+          <Image
+            className="modal-image"
+            src={props.url}
+            alt={props.title || props.filename}
+            label={<Label attached="bottom" content={props.filename} />}
+            wrapped
+          />
+        </Modal.Content>
+      </Modal>
+    </>
+  );
+}

--- a/src/details/wrapped-image.tsx
+++ b/src/details/wrapped-image.tsx
@@ -1,5 +1,14 @@
-import {Icon, Image, Label, Modal, Placeholder} from 'semantic-ui-react';
-import {useState} from 'react';
+import {
+  Container,
+  Icon,
+  Image,
+  Label,
+  Message,
+  Modal,
+  Placeholder,
+} from 'semantic-ui-react';
+import {SyntheticEvent, useState} from 'react';
+import {FormattedMessage} from 'react-intl';
 
 interface Props {
   url: string;
@@ -10,13 +19,28 @@ interface Props {
 export function WrappedImage(props: Props) {
   const [imageOpen, setImageOpen] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageFailed, setImageFailed] = useState(false);
+  const [imageSrc, setImageSrc] = useState('');
 
+  if (imageLoaded && imageSrc !== props.url) {
+    setImageLoaded(false);
+  }
   return (
     <>
       <Image
         className={imageLoaded ? 'loaded-image-thumbnail' : 'hidden-image'}
         onClick={() => setImageOpen(true)}
-        onLoad={() => setImageLoaded(true)}
+        onLoad={() => {
+          setImageLoaded(true);
+          setImageSrc(props.url);
+          setImageFailed(false);
+        }}
+        onError={(e: SyntheticEvent<HTMLImageElement, Event>) => {
+          setImageLoaded(true);
+          setImageSrc(props.url);
+          setImageFailed(true);
+          e.currentTarget.alt = '';
+        }}
         src={props.url}
         alt={props.title || props.filename}
         centered={true}
@@ -26,6 +50,18 @@ export function WrappedImage(props: Props) {
       >
         <Placeholder.Image square />
       </Placeholder>
+      {imageFailed && (
+        <Container fluid textAlign="center">
+          <Message negative compact>
+            <Message.Header>
+              <FormattedMessage
+                id="error.failed_to_load_image"
+                defaultMessage={'Failed to load image file'}
+              />
+            </Message.Header>
+          </Message>
+        </Container>
+      )}
       <Modal
         basic
         size="large"
@@ -35,7 +71,7 @@ export function WrappedImage(props: Props) {
         onOpen={() => setImageOpen(true)}
         centered={false}
       >
-        <Modal.Header className="center">{props.title}</Modal.Header>
+        <Modal.Header>{props.title}</Modal.Header>
         <Modal.Content image>
           <Image
             className="modal-image"

--- a/src/index.css
+++ b/src/index.css
@@ -146,6 +146,7 @@ div.zoom {
 .details {
   padding: 15px 0px;
   border-bottom: 1px solid rgba(34,36,38,.15);
+  overflow-x: hidden;
 }
 
 .details .ui.items .item .content {
@@ -164,6 +165,12 @@ div.zoom {
   min-width: 40%;
 }
 
+.details .person-image {
+  max-width: 282px;
+  width: 320px; /*fixed width to avoid image rescaling when scrollbar appears*/
+}
+
+
 .ui.form .field.no-margin {
   margin: 0;
 }
@@ -175,4 +182,22 @@ div.zoom {
 .limit-height {
   height: 300px;
   overflow-y: scroll;
+}
+
+.loaded-image-thumbnail {
+  cursor: zoom-in;
+}
+
+.hidden-image {
+ display: none !important;
+}
+
+.modal-image {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.image-placeholder {
+  height: 100%;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,7 @@ body, html {
   flex: 0 0 320px;
   overflow: auto;
   border-left: solid #ccc 1px;
+  overflow-x: hidden;
 }
 
 .hidden {
@@ -146,7 +147,6 @@ div.zoom {
 .details {
   padding: 15px 0px;
   border-bottom: 1px solid rgba(34,36,38,.15);
-  overflow-x: hidden;
 }
 
 .details .ui.items .item .content {
@@ -166,10 +166,10 @@ div.zoom {
 }
 
 .details .person-image {
-  max-width: 282px;
-  width: 320px; /*fixed width to avoid image rescaling when scrollbar appears*/
+  max-width: 289px;
+  width: 289px;
+  padding: 0 10px;
 }
-
 
 .ui.form .field.no-margin {
   margin: 0;
@@ -196,6 +196,11 @@ div.zoom {
   display: block;
   margin-left: auto;
   margin-right: auto;
+}
+
+.modal-image .ui.attached.label {
+  width: auto;
+  min-width: 100%;
 }
 
 .image-placeholder {

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -78,6 +78,7 @@
   "error.WIKITREE_ID_NOT_PROVIDED": "Identyfikator WikiTree nie został podany",
   "error.WIKITREE_PROFILE_NOT_ACCESSIBLE": "Profil WikiTree {id} nie jest dostępny",
   "error.WIKITREE_PROFILE_NOT_FOUND": "Profil WikiTree {id} nie istnieje",
+  "error.failed_to_load_image": "Błąd podczas pobierania pliku ze zdjęciem",
   "wikitree.private": "Prywatne",
   "tab.info": "Info",
   "tab.settings": "Ustawienia",

--- a/src/util/age_util.ts
+++ b/src/util/age_util.ts
@@ -118,7 +118,8 @@ function calcDateDifferenceInYears(
   const startYear = firstDateObject.getUTCFullYear();
 
   let yearDiff = secondDateObject.getUTCFullYear() - startYear;
-  let monthDiff = secondDateObject.getUTCMonth() - firstDateObject.getUTCMonth();
+  let monthDiff =
+    secondDateObject.getUTCMonth() - firstDateObject.getUTCMonth();
   if (monthDiff < 0) {
     yearDiff--;
     monthDiff += 12;

--- a/src/util/gedcom_util.ts
+++ b/src/util/gedcom_util.ts
@@ -192,10 +192,10 @@ export function normalizeGedcom(gedcom: JsonGedcomData): JsonGedcomData {
   return sortSpouses(sortChildren(gedcom));
 }
 
-const IMAGE_EXTENSIONS = ['.jpg', '.png', '.gif'];
+const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif'];
 
 /** Returns true if the given file name has a known image extension. */
-function isImageFile(fileName: string): boolean {
+export function isImageFile(fileName: string): boolean {
   const lowerName = fileName.toLowerCase();
   return IMAGE_EXTENSIONS.some((ext) => lowerName.endsWith(ext));
 }
@@ -281,4 +281,13 @@ export function getName(person: GedcomEntry): string | undefined {
   );
   const name = notMarriedName || names[0];
   return name?.data.replace(/\//g, '');
+}
+
+export function getFileName(fileEntry: GedcomEntry): string | undefined {
+  const fileTitle = fileEntry?.tree.find((entry) => entry.tag === 'TITL')?.data;
+
+  const fileExtension = fileEntry?.tree.find((entry) => entry.tag === 'FORM')
+    ?.data;
+
+  return fileTitle && fileExtension && fileTitle + '.' + fileExtension;
 }


### PR DESCRIPTION
Hi, This PR contains changes required to display person photos in details panel. 

Scope of the PR:

* Display photos for data from Gedcom files saved as 'http/https' URL in `ObJE` tag (Works with gramps plugin)
* Display photos for data from Wikitree
* Possibility to zoom-in photos 
* Display fancy placeholder when image file is big and loading for too long
* Error handling for invalid photo URLs 
* Added jpeg to supported image extensions  

How does it look:
![Display_panel_photo](https://user-images.githubusercontent.com/15907129/167952821-fcd89d3d-f867-4a37-9480-5fb73bb5595d.png)
![photo_modal](https://user-images.githubusercontent.com/15907129/167952838-b893d9f7-784a-4cbc-b3ef-9fa88d1b06f2.png)

