### PR TITLE
Display sources and links to non-image files in details panel

### DIFF
--- a/src/details/additional-files.tsx
+++ b/src/details/additional-files.tsx
@@ -1,0 +1,29 @@
+import {List} from 'semantic-ui-react';
+
+export interface FileEntry {
+  url: string;
+  filename?: string;
+}
+
+interface Props {
+  files?: FileEntry[];
+}
+
+export function AdditionalFiles({files}: Props) {
+  if (!files?.length) return null;
+
+  return (
+    <List>
+      {files.map((file, index) => (
+        <List.Item key={index}>
+          <List.Icon verticalAlign="middle" name="circle" size="tiny" />
+          <List.Content>
+            <a target="_blank" href={file.url} rel="noopener noreferrer">
+              {file.filename || file.url.split('/').pop() || file.url}
+            </a>
+          </List.Content>
+        </List.Item>
+      ))}
+    </List>
+  );
+}

--- a/src/details/event-extras.tsx
+++ b/src/details/event-extras.tsx
@@ -1,7 +1,5 @@
-import * as React from 'react';
 import {useState} from 'react';
-import {FormattedMessage, IntlShape, useIntl} from 'react-intl';
-import Linkify from 'react-linkify';
+import {FormattedMessage} from 'react-intl';
 import {
   Icon,
   Item,
@@ -11,9 +9,9 @@ import {
   Popup,
   Tab,
 } from 'semantic-ui-react';
-import {DateOrRange} from 'topola';
-import {formatDateOrRange} from '../util/date_util';
+import {AdditionalFiles, FileEntry} from './additional-files';
 import {MultilineText} from './multiline-text';
+import {Source, Sources} from './sources';
 import {WrappedImage} from './wrapped-image';
 
 export interface Image {
@@ -22,19 +20,12 @@ export interface Image {
   title?: string;
 }
 
-export interface Source {
-  title?: string;
-  author?: string;
-  page?: string;
-  date?: DateOrRange;
-  publicationInfo?: string;
-}
-
 interface Props {
   images?: Image[];
   notes?: string[][];
   sources?: Source[];
   indi: string;
+  files?: FileEntry[];
 }
 
 function eventImages(images: Image[] | undefined) {
@@ -69,37 +60,7 @@ function eventNotes(notes: string[][] | undefined) {
   );
 }
 
-function eventSources(sources: Source[] | undefined, intl: IntlShape) {
-  return (
-    !!sources?.length && (
-      <List>
-        {sources.map((source, index) => (
-          <List.Item key={index}>
-            <List.Icon verticalAlign="middle" name="circle" size="tiny" />
-            <List.Content>
-              <List.Header>
-                <Linkify properties={{target: '_blank'}}>
-                  {[source.author, source.title, source.publicationInfo]
-                    .filter((sourceElement) => sourceElement)
-                    .join(', ')}
-                </Linkify>
-              </List.Header>
-              <List.Description>
-                <Linkify properties={{target: '_blank'}}>{source.page}</Linkify>
-                {source.date
-                  ? ' [' + formatDateOrRange(source.date, intl) + ']'
-                  : null}
-              </List.Description>
-            </List.Content>
-          </List.Item>
-        ))}
-      </List>
-    )
-  );
-}
-
 export function EventExtras(props: Props) {
-  const intl = useIntl();
   const [activeIndex, setActiveIndex] = useState(-1);
   const [indi, setIndi] = useState('');
 
@@ -109,7 +70,7 @@ export function EventExtras(props: Props) {
   }
 
   function handleTabOnClick(
-    event: React.MouseEvent<HTMLAnchorElement>,
+    _event: React.MouseEvent<HTMLAnchorElement>,
     menuItemProps: MenuItemProps,
   ) {
     menuItemProps.index !== undefined && activeIndex !== menuItemProps.index
@@ -162,10 +123,37 @@ export function EventExtras(props: Props) {
         />
       </Menu.Item>
     ),
-    render: () => <Tab.Pane>{eventSources(props.sources, intl)}</Tab.Pane>,
+    render: () => (
+      <Tab.Pane>
+        <Sources sources={props.sources} />
+      </Tab.Pane>
+    ),
   };
 
-  const panes = [imageTab, noteTab, sourceTab].flatMap((tab) =>
+  const filesTab = props.files?.length && {
+    menuItem: (
+      <Menu.Item fitted key="files" onClick={handleTabOnClick}>
+        <Popup
+          content={
+            <FormattedMessage
+              id="extras.files"
+              defaultMessage="Additonal files"
+            />
+          }
+          size="mini"
+          position="bottom center"
+          trigger={<Icon circular name="file alternate outline" />}
+        />
+      </Menu.Item>
+    ),
+    render: () => (
+      <Tab.Pane>
+        <AdditionalFiles files={props.files} />
+      </Tab.Pane>
+    ),
+  };
+
+  const panes = [imageTab, noteTab, sourceTab, filesTab].flatMap((tab) =>
     tab ? [tab] : [],
   );
 

--- a/src/details/event-extras.tsx
+++ b/src/details/event-extras.tsx
@@ -9,9 +9,10 @@ import {
   Popup,
   Tab,
 } from 'semantic-ui-react';
+import {Source} from '../util/gedcom_util';
 import {AdditionalFiles, FileEntry} from './additional-files';
 import {MultilineText} from './multiline-text';
-import {Source, Sources} from './sources';
+import {Sources} from './sources';
 import {WrappedImage} from './wrapped-image';
 
 export interface Image {

--- a/src/details/events.tsx
+++ b/src/details/events.tsx
@@ -15,11 +15,13 @@ import {
   getImageFileEntry,
   getName,
   getNonImageFileEntry,
+  mapToSource,
   pointerToId,
+  resolveDate,
+  Source,
 } from '../util/gedcom_util';
 import {FileEntry} from './additional-files';
 import {EventExtras, Image} from './event-extras';
-import {Source} from './sources';
 import {TranslatedTag} from './translated-tag';
 
 function PersonLink(props: {person: GedcomEntry}) {
@@ -170,45 +172,7 @@ function eventFiles(entry: GedcomEntry, gedcom: GedcomData): Image[] {
 function eventSources(entry: GedcomEntry, gedcom: GedcomData): Source[] {
   return entry.tree
     .filter((subEntry) => 'SOUR' === subEntry.tag)
-    .map((sourceEntryReference) => {
-      const sourceEntry = dereference(
-        sourceEntryReference,
-        gedcom,
-        (gedcom) => gedcom.other,
-      );
-
-      const title = sourceEntry.tree.find(
-        (subEntry) => 'TITL' === subEntry.tag,
-      );
-
-      const abbr = sourceEntry.tree.find((subEntry) => 'ABBR' === subEntry.tag);
-
-      const author = sourceEntry.tree.find(
-        (subEntry) => 'AUTH' === subEntry.tag,
-      );
-
-      const publicationInfo = sourceEntry.tree.find(
-        (subEntry) => 'PUBL' === subEntry.tag,
-      );
-
-      const page = sourceEntryReference.tree.find(
-        (subEntry) => 'PAGE' === subEntry.tag,
-      );
-
-      const sourceData = sourceEntryReference.tree.find(
-        (subEntry) => 'DATA' === subEntry.tag,
-      );
-
-      const date = sourceData ? resolveDate(sourceData) : undefined;
-
-      return {
-        title: title?.data || abbr?.data,
-        author: author?.data,
-        page: page?.data,
-        date: date ? getDate(date.data) : undefined,
-        publicationInfo: publicationInfo?.data,
-      };
-    });
+    .map((sourceEntryReference) => mapToSource(sourceEntryReference, gedcom));
 }
 
 function eventNotes(entry: GedcomEntry, gedcom: GedcomData): string[][] {
@@ -250,10 +214,6 @@ function toIndiEvent(
       indi: indi,
     },
   ];
-}
-
-function resolveDate(entry: GedcomEntry) {
-  return entry.tree.find((subEntry) => subEntry.tag === 'DATE');
 }
 
 function toFamilyEvents(

--- a/src/details/sources.tsx
+++ b/src/details/sources.tsx
@@ -1,16 +1,8 @@
 import {useIntl} from 'react-intl';
 import Linkify from 'react-linkify';
 import {List} from 'semantic-ui-react';
-import {DateOrRange} from 'topola';
 import {formatDateOrRange} from '../util/date_util';
-
-export interface Source {
-  title?: string;
-  author?: string;
-  page?: string;
-  date?: DateOrRange;
-  publicationInfo?: string;
-}
+import {Source} from '../util/gedcom_util';
 
 interface Props {
   sources?: Source[];

--- a/src/details/sources.tsx
+++ b/src/details/sources.tsx
@@ -1,0 +1,46 @@
+import {useIntl} from 'react-intl';
+import Linkify from 'react-linkify';
+import {List} from 'semantic-ui-react';
+import {DateOrRange} from 'topola';
+import {formatDateOrRange} from '../util/date_util';
+
+export interface Source {
+  title?: string;
+  author?: string;
+  page?: string;
+  date?: DateOrRange;
+  publicationInfo?: string;
+}
+
+interface Props {
+  sources?: Source[];
+}
+
+export function Sources({sources}: Props) {
+  const intl = useIntl();
+
+  if (!sources?.length) return null;
+
+  return (
+    <List>
+      {sources.map((source, index) => (
+        <List.Item key={index}>
+          <List.Icon verticalAlign="middle" name="circle" size="tiny" />
+          <List.Content>
+            <List.Header>
+              <Linkify properties={{target: '_blank'}}>
+                {[source.author, source.title, source.publicationInfo]
+                  .filter((sourceElement) => !!sourceElement)
+                  .join(', ')}
+              </Linkify>
+            </List.Header>
+            <List.Description>
+              <Linkify properties={{target: '_blank'}}>{source.page}</Linkify>
+              {source.date && ` [${formatDateOrRange(source.date, intl)}]`}
+            </List.Description>
+          </List.Content>
+        </List.Item>
+      ))}
+    </List>
+  );
+}

--- a/src/details/translated-tag.tsx
+++ b/src/details/translated-tag.tsx
@@ -22,6 +22,7 @@ const TAG_DESCRIPTIONS = new Map([
   ['OCCU', 'Occupation'],
   ['TITL', 'Title'],
   ['WWW', 'WWW'],
+  ['OBJE', 'Additional files'],
   ['birth', 'Birth name'],
   ['married', 'Married name'],
   ['maiden', 'Maiden name'],

--- a/src/details/translated-tag.tsx
+++ b/src/details/translated-tag.tsx
@@ -23,6 +23,7 @@ const TAG_DESCRIPTIONS = new Map([
   ['TITL', 'Title'],
   ['WWW', 'WWW'],
   ['OBJE', 'Additional files'],
+  ['SOUR', 'Sources'],
   ['birth', 'Birth name'],
   ['married', 'Married name'],
   ['maiden', 'Maiden name'],

--- a/src/index.css
+++ b/src/index.css
@@ -153,13 +153,13 @@ div.zoom {
   padding: 0 15px;
 }
 
-.details .event-header {
+.details .item-header {
   justify-content: space-between;
   display: flex;
   word-break: break-word;
 }
 
-.details .event-header .header {
+.details .item-header .header {
   text-transform: uppercase;
   margin: 0;
   min-width: 40%;

--- a/src/translations/bg.json
+++ b/src/translations/bg.json
@@ -62,6 +62,7 @@
   "gedcom.RIN": "ID",
   "gedcom.TITL": "Обръщение",
   "gedcom.WWW": "Линк",
+  "gedcom.OBJE": "Допълнителни файлове",
   "gedcom._UPD": "Последно обновление",
   "gedcom.birth": "Рождено име",
   "gedcom.married": "Име след брак",
@@ -106,5 +107,6 @@
   "name.unknown_name": "Неизвестно име",
   "extras.images": "Изображение",
   "extras.notes": "Бележки",
-  "extras.sources": "Източници"
+  "extras.sources": "Източници",
+  "extras.files": "Допълнителни файлове"
 }

--- a/src/translations/bg.json
+++ b/src/translations/bg.json
@@ -63,6 +63,7 @@
   "gedcom.TITL": "Обръщение",
   "gedcom.WWW": "Линк",
   "gedcom.OBJE": "Допълнителни файлове",
+  "gedcom.SOUR": "Източници",
   "gedcom._UPD": "Последно обновление",
   "gedcom.birth": "Рождено име",
   "gedcom.married": "Име след брак",

--- a/src/translations/cs.json
+++ b/src/translations/cs.json
@@ -64,6 +64,7 @@
   "gedcom.TITL": "Titul",
   "gedcom.WWW": "Stránka WWW",
   "gedcom.OBJE": "Další soubory",
+  "gedcom.SOUR": "Zdroje",
   "gedcom.RELI": "Vyznání",
   "gedcom._UPD": "Poslední aktualizace",
   "gedcom.birth": "Rodné jméno",

--- a/src/translations/cs.json
+++ b/src/translations/cs.json
@@ -63,6 +63,7 @@
   "gedcom.RIN": "ID",
   "gedcom.TITL": "Titul",
   "gedcom.WWW": "Stránka WWW",
+  "gedcom.OBJE": "Další soubory",
   "gedcom.RELI": "Vyznání",
   "gedcom._UPD": "Poslední aktualizace",
   "gedcom.birth": "Rodné jméno",
@@ -107,5 +108,6 @@
   "name.unknown_name": "N.N.",
   "extras.images": "Obrázky",
   "extras.notes": "Poznámky",
-  "extras.sources": "Zdroje"
+  "extras.sources": "Zdroje",
+  "extras.files": "Další soubory"
 }

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -50,6 +50,7 @@
   "gedcom.RIN": "ID",
   "gedcom.TITL": "Titel",
   "gedcom.WWW": "Website",
+  "gedcom.OBJE": "Zusätzliche Dateien",
   "gedcom._UPD": "Zuletzt aktualisiert",
   "gedcom.birth": "Geburtsname",
   "gedcom.married": "Ehenamen",

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -51,6 +51,7 @@
   "gedcom.TITL": "Titel",
   "gedcom.WWW": "Website",
   "gedcom.OBJE": "Zusätzliche Dateien",
+  "gedcom.SOUR": "Quellen",
   "gedcom._UPD": "Zuletzt aktualisiert",
   "gedcom.birth": "Geburtsname",
   "gedcom.married": "Ehenamen",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -61,6 +61,7 @@
   "gedcom.TITL": "Titre",
   "gedcom.WWW": "Site Web",
   "gedcom.OBJE": "Fichiers supplémentaires",
+  "gedcom.SOUR": "Sources",
   "gedcom._UPD": "Dernière mise à jour",
   "gedcom.MARR": "Mariage",
   "gedcom.DIV": "Divorce",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -60,6 +60,7 @@
   "gedcom.RIN": "ID",
   "gedcom.TITL": "Titre",
   "gedcom.WWW": "Site Web",
+  "gedcom.OBJE": "Fichiers supplémentaires",
   "gedcom._UPD": "Dernière mise à jour",
   "gedcom.MARR": "Mariage",
   "gedcom.DIV": "Divorce",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -53,6 +53,7 @@
   "gedcom.TITL": "Titolo",
   "gedcom.WWW": "Sito web",
   "gedcom.OBJE": "File aggiuntivi",
+  "gedcom.SOUR": "Fonti",
   "gedcom._UPD": "Ultimo aggiornamento",
   "gedcom.birth": "Nome alla nascita",
   "gedcom.married": "Nome da coniugato/a",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -52,6 +52,7 @@
   "gedcom.RIN": "ID",
   "gedcom.TITL": "Titolo",
   "gedcom.WWW": "Sito web",
+  "gedcom.OBJE": "File aggiuntivi",
   "gedcom._UPD": "Ultimo aggiornamento",
   "gedcom.birth": "Nome alla nascita",
   "gedcom.married": "Nome da coniugato/a",

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -55,6 +55,7 @@
   "gedcom.RIN": "ID",
   "gedcom.TITL": "Tytuł",
   "gedcom.WWW": "Strona WWW",
+  "gedcom.OBJE": "Dodatkowe pliki",
   "gedcom._UPD": "Ostatnia aktualizacja",
   "gedcom.MARR": "Małżeństwo",
   "gedcom.DIV": "Rozwód",
@@ -94,5 +95,6 @@
   "name.unknown_name": "N.N.",
   "extras.images": "Zdjęcia",
   "extras.notes": "Notatki",
-  "extras.sources": "Źródła"
+  "extras.sources": "Źródła",
+  "extras.files": "Dodatkowe pliki"
 }

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -56,6 +56,7 @@
   "gedcom.TITL": "Tytuł",
   "gedcom.WWW": "Strona WWW",
   "gedcom.OBJE": "Dodatkowe pliki",
+  "gedcom.SOUR": "Źródła",
   "gedcom._UPD": "Ostatnia aktualizacja",
   "gedcom.MARR": "Małżeństwo",
   "gedcom.DIV": "Rozwód",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -60,6 +60,7 @@
   "gedcom.RIN": "ID",
   "gedcom.TITL": "Титул",
   "gedcom.WWW": "Веб-сайт WWW",
+  "gedcom.OBJE": "Дополнительные файлы",
   "gedcom._UPD": "Последнее обновление",
   "gedcom.birth": "Имя при рождении",
   "gedcom.married": "Имя в браке",
@@ -97,5 +98,6 @@
   "name.unknown_name": "Н.И.",
   "extras.images": "Картинки",
   "extras.notes": "Примечание",
-  "extras.sources": "Источники"
+  "extras.sources": "Источники",
+  "extras.files": "Дополнительные файлы"
 }

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -61,6 +61,7 @@
   "gedcom.TITL": "Титул",
   "gedcom.WWW": "Веб-сайт WWW",
   "gedcom.OBJE": "Дополнительные файлы",
+  "gedcom.SOUR": "Источники",
   "gedcom._UPD": "Последнее обновление",
   "gedcom.birth": "Имя при рождении",
   "gedcom.married": "Имя в браке",

--- a/src/util/gedcom_util.ts
+++ b/src/util/gedcom_util.ts
@@ -1,6 +1,8 @@
 import {GedcomEntry, parse as parseGedcom} from 'parse-gedcom';
 import {
+  DateOrRange,
   gedcomEntriesToJson,
+  getDate,
   JsonFam,
   JsonGedcomData,
   JsonImage,
@@ -23,6 +25,14 @@ export interface GedcomData {
 export interface TopolaData {
   chartData: JsonGedcomData;
   gedcom: GedcomData;
+}
+
+export interface Source {
+  title?: string;
+  author?: string;
+  page?: string;
+  date?: DateOrRange;
+  publicationInfo?: string;
 }
 
 /**
@@ -316,4 +326,47 @@ export function getImageFileEntry(
   objectEntry: GedcomEntry,
 ): GedcomEntry | undefined {
   return findFileEntry(objectEntry, (entry) => isImageFile(entry.data));
+}
+
+export function resolveDate(entry: GedcomEntry) {
+  return entry.tree.find((subEntry) => subEntry.tag === 'DATE');
+}
+
+export function mapToSource(
+  sourceEntryReference: GedcomEntry,
+  gedcom: GedcomData,
+) {
+  const sourceEntry = dereference(
+    sourceEntryReference,
+    gedcom,
+    (gedcom) => gedcom.other,
+  );
+
+  const title = sourceEntry.tree.find((subEntry) => 'TITL' === subEntry.tag);
+
+  const abbr = sourceEntry.tree.find((subEntry) => 'ABBR' === subEntry.tag);
+
+  const author = sourceEntry.tree.find((subEntry) => 'AUTH' === subEntry.tag);
+
+  const publicationInfo = sourceEntry.tree.find(
+    (subEntry) => 'PUBL' === subEntry.tag,
+  );
+
+  const page = sourceEntryReference.tree.find(
+    (subEntry) => 'PAGE' === subEntry.tag,
+  );
+
+  const sourceData = sourceEntryReference.tree.find(
+    (subEntry) => 'DATA' === subEntry.tag,
+  );
+
+  const date = sourceData ? resolveDate(sourceData) : undefined;
+
+  return {
+    title: title?.data || abbr?.data,
+    author: author?.data,
+    page: page?.data,
+    date: date ? getDate(date.data) : undefined,
+    publicationInfo: publicationInfo?.data,
+  };
 }

--- a/src/util/gedcom_util.ts
+++ b/src/util/gedcom_util.ts
@@ -296,13 +296,24 @@ export function getFileName(fileEntry: GedcomEntry): string | undefined {
   return fileTitle && fileExtension && fileTitle + '.' + fileExtension;
 }
 
-export function getImageFileEntry(
+function findFileEntry(
   objectEntry: GedcomEntry,
+  predicate: (entry: GedcomEntry) => boolean,
 ): GedcomEntry | undefined {
   return objectEntry.tree.find(
     (entry) =>
-      entry.tag === 'FILE' &&
-      entry.data.startsWith('http') &&
-      isImageFile(entry.data),
+      entry.tag === 'FILE' && entry.data.startsWith('http') && predicate(entry),
   );
+}
+
+export function getNonImageFileEntry(
+  objectEntry: GedcomEntry,
+): GedcomEntry | undefined {
+  return findFileEntry(objectEntry, (entry) => !isImageFile(entry.data));
+}
+
+export function getImageFileEntry(
+  objectEntry: GedcomEntry,
+): GedcomEntry | undefined {
+  return findFileEntry(objectEntry, (entry) => isImageFile(entry.data));
 }


### PR DESCRIPTION
Inspired by the idea from #203, this MR adds the ability to display sources and links to non-image files in the details panel.
Initially, I planned to support only `OBJE` gedcom entries, but then I noticed that I already implemented support for `SOUR` in events a few years ago. With a small refactor, both persons and events now support `OBJE` and `SOUR` gedcom entries.

<img width="307" height="378" alt="image" src="https://github.com/user-attachments/assets/17007c93-e528-4fab-afcf-884ef0ffcb6e" />
<img width="319" height="158" alt="image" src="https://github.com/user-attachments/assets/5051cd17-075d-4321-a6cb-3d4b1b86ec7a" />

Can be easily tested in gramps, by adding source citations and media objects to the person and their events.