### PR TITLE
feat: Show full name in sidebar

### DIFF
--- a/src/sidepanel/details/details.tsx
+++ b/src/sidepanel/details/details.tsx
@@ -149,18 +149,20 @@ function noteDetails(noteEntryReference: GedcomEntry, gedcom: GedcomData) {
 }
 
 function nameDetails(entry: GedcomEntry) {
-  const given = entry.tree.find((entry) => entry.tag === 'GIVN')?.data;
-  const surname = entry.tree.find((entry) => entry.tag === 'SURN')?.data;
   const prefix = entry.tree.find((entry) => entry.tag === 'NPFX')?.data;
-  const suffix = entry.tree.find((entry) => entry.tag === 'NSFX')?.data;
+  const given = entry.tree.find((entry) => entry.tag === 'GIVN')?.data;
   const rufname = entry.tree.find((entry) => entry.tag === '_RUFNAME')?.data;
   const nickname = entry.tree.find((entry) => entry.tag === 'NICK')?.data;
+  const surnamePrefix = entry.tree.find((entry) => entry.tag === 'SPFX')?.data;
+  const surname = entry.tree.find((entry) => entry.tag === 'SURN')?.data;
+  const suffix = entry.tree.find((entry) => entry.tag === 'NSFX')?.data;
 
   const fullNameParts = [
     prefix,
     given,
     rufname && `"${rufname}"`,
     nickname && `(${nickname})`,
+    surnamePrefix,
     surname,
     suffix,
   ].filter(Boolean);


### PR DESCRIPTION
This PR changes the sidebar view to compose full names from the following instead of just using the `NAME` field:

* `NPFX` - name prefix (e.g. "Capt.")
* `GIVN` - given name
* `_RUFNAME` - call name, using by GRAMPS and other programs.
* `NICK` - nickname
* `SPFX` - surname prefix (e.g. "van der")
* `SURN` - surname
* `NSFX` - name suffix (e.g. "Jr.")

This is composed using the form `Prefix Given "Call" (Nickname) SurnamePrefix Surname Suffix`.

It should be noted that `_RUFNAME` should be a part of the given name, and thus this information is duplicated. Some programs underline this instead if I remember correctly, so this is something that could be done instead though I feel it is less intuitive.

Also, this will obviously override if a GEDCOM file has different name ordering, but this would only be able to be resolved by adding a setting for name ordering.

This is something that could also be ported to https://github.com/PeWu/topola itself. Closes #153.