### PR TITLE
Display types for attributes/facts in the sidebar

### DIFF
--- a/src/sidepanel/details/details.tsx
+++ b/src/sidepanel/details/details.tsx
@@ -66,17 +66,29 @@ function attributeDetails(entry: GedcomEntry) {
       .trim();
 
   let attributeValue = getData(entry).join(' ').trim();
-
-  return (
-    <>
-      <Header sub>
-        <TranslatedTag tag={entry.tag} />
-      </Header>
-      <div>
-        <b>{attributeName}</b>: {attributeValue}
-      </div>
-    </>
-  );
+  if(attributeName) {
+    return (
+        <>
+          <Header sub>
+            <TranslatedTag tag={entry.tag}/>
+          </Header>
+          <div>
+            <b>{attributeName}</b>: {attributeValue}
+          </div>
+        </>
+    );
+  } else {
+    return (
+      <>
+        <Header sub>
+          <TranslatedTag tag={entry.tag}/>
+        </Header>
+        <div>
+          {attributeValue}
+        </div>
+      </>
+    );
+  }
 }
 
 function imageDetails(objectEntryReference: GedcomEntry, gedcom: GedcomData) {


### PR DESCRIPTION
In my research I actively use person's attributes in Gramps to highlight static facts about persons. Gramps imports attributes as a GEDCOM's `FACT` tag. 

According to GEDCOM specification `FACT` tag can be qualified by `TYPE` tag as well. Something like

```
1 FACT Hiking, astronomy, computer science
2 TYPE Hobby
```

While `FACT` tags are displayed, they look quite confusing without corresponding type information. A section "FACT 170" says nothing interesting about a person.

<img width="369" height="431" alt="topola_attributes_without_names" src="https://github.com/user-attachments/assets/1d875af0-5cfe-44e8-ae8f-866e565ff6a3" />

In this PR I have fixed this behavior and display a corresponding attribute's type. So instead of just "FACT 170" you can find "FACT Height: 170" in the sidebar

<img width="357" height="435" alt="topola_attributes_with_names" src="https://github.com/user-attachments/assets/960e95fd-1ddf-4a8d-bf68-75ffc64afb1c" />

PS: TypeScript/React is not my native language (I am fond of Java/Spring), so I am ready for feedback as well