### PR TITLE
Support all Vite environment variables for Windows scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,10 +83,10 @@
   "scripts": {
     "start": "run-script-os",
     "start:default": "GENERATE_SOURCEMAP=false VITE_CHANGELOG=`cat CHANGELOG.md` VITE_GIT_SHA=`git rev-parse --short HEAD` VITE_GIT_TIME=`git log -1 --format=%ci` vite",
-    "start:windows": "set \"GENERATE_SOURCEMAP=false\" && vite",
+    "start:windows": "powershell -Command \"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; $env:GENERATE_SOURCEMAP='false'; $env:VITE_CHANGELOG = Get-Content -Path \"CHANGELOG.md\" -Raw; $env:VITE_GIT_SHA=$(git rev-parse --short HEAD); $env:VITE_GIT_TIME=$(git log -1 --format='%ci'); vite\"",
     "build": "run-script-os",
     "build:default": "GENERATE_SOURCEMAP=false VITE_CHANGELOG=`cat CHANGELOG.md` VITE_GIT_SHA=`git rev-parse --short HEAD` VITE_GIT_TIME=`git log -1 --format=%ci` tsc && vite build",
-    "build:windows": "set \"GENERATE_SOURCEMAP=false\" && tsc && vite build",
+    "build:windows": "powershell -Command \"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; $env:GENERATE_SOURCEMAP='false'; $env:VITE_CHANGELOG = Get-Content -Path \"CHANGELOG.md\" -Raw; $env:VITE_GIT_SHA=$(git rev-parse --short HEAD); $env:VITE_GIT_TIME=$(git log -1 --format='%ci'); tsc; vite build",
     "test": "jest",
     "prettier": "prettier --write src/**/*.{ts,tsx,json} && prettier --write src/*.{ts,tsx,json}",
     "predeploy": "npm run build",


### PR DESCRIPTION
This improves upon #81 and #184 by matching all of the environment variables used in the `default` scripts.

It fixes the issue seen in #229 for local builds on Windows, but likely not for the `gh-pages` branch of the repo.

I had to run PowerShell from within cmd.exe in order to make it easier to populate `VITE_CHANGELOG`, as that is the hardest environment variable to populate correctly in cmd.exe.

Tested on Windows 11.  I could not get the build working in WSL with Ubuntu, so it is _not_ tested there, but non-Windows environments should not be impacted by this change.