### PR TITLE
Adjust load_data test to accommodate test.ged file length on Windows

### DIFF
--- a/src/datasource/load_data.spec.ts
+++ b/src/datasource/load_data.spec.ts
@@ -10,7 +10,9 @@ describe('loadFile', () => {
     const file = readFileSync('src/datasource/testdata/test.ged');
     const blob = new Blob([file]) as globalThis.Blob;
     const {gedcom, images} = await loadFile(blob);
-    expect(gedcom.length).toBe(4408);
+    // File length may differ between Linux and Windows due to line endings (\n vs \r\n)
+    // So, check for a set of values instead of exactly one value
+    expect([4408, 4765]).toContain(gedcom.length);
     expect(images).toEqual(new Map());
   });
 


### PR DESCRIPTION
Tested with `npm test` - this test was previously failing, and now it passes.