### PR TITLE
Reconfigure cy:start-and-run script to use run-script-os to support Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,9 @@
     "predeploy-wikitree": "npm run build",
     "deploy-wikitree": "./deploy-wikitree.sh",
     "cy:run": "cypress run",
-    "cy:start-and-run": "BROWSER=none start-server-and-test start localhost:3000 cy:run"
+    "cy:start-and-run": "run-script-os",
+    "cy:start-and-run:default": "BROWSER=none start-server-and-test start localhost:3000 cy:run",
+    "cy:start-and-run:windows": "set BROWSER=none && start-server-and-test start localhost:3000 cy:run"
   },
   "homepage": ".",
   "browserslist": [


### PR DESCRIPTION
Windows CMD needs a slightly different syntax from the default.

Confirmed this works on Windows 11 by running `npm run cy:start-and-run`.