### PR TITLE
Build configuration option to remove Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,24 @@ set VITE_STATIC_URL=https://example.org/sample.ged && npm run build
 
 The `dist/` folder will contain files that can be hosted on a Web server.
 
+### Build without Google Analytics
+
+Set `VITE_GOOGLE_ANALYTICS=false` to exclude Google Analytics from the build output.  This will remove the external JavaScript dependency.
+
+```shell
+VITE_GOOGLE_ANALYTICS=false npm run build
+```
+
+<details>
+<summary>For Windows CMD:</summary>
+
+```cmd
+set VITE_GOOGLE_ANALYTICS=false && npm run build
+```
+</details>
+
+This may be combined with the other build environment variables described above.
+
 ### Alternative build
 
 The [topola-webpack](https://github.com/develancer/topola-webpack) tool can build a Topola Genealogy Viewer package bundled together with a GEDCOM file.

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <!-- GOOGLE_ANALYTICS_START -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-32GXR2WF6S"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -9,6 +9,7 @@
       gtag('js', new Date());
       gtag('config', 'G-32GXR2WF6S');
     </script>
+    <!-- GOOGLE_ANALYTICS_END -->
     <meta charset="utf-8">
     <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no">
     <link rel="icon" href="favicon.png" type="image/png"/>

--- a/src/util/analytics_noop.ts
+++ b/src/util/analytics_noop.ts
@@ -1,0 +1,2 @@
+/** No-op function for analytics. */
+export function analyticsEvent(action: string, data?: any) { }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,11 +1,35 @@
 import {defineConfig} from 'vite';
+import {resolve} from 'path';
 import react from '@vitejs/plugin-react';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   // depending on your application, base can also be "/"
   base: '',
-  plugins: [react(), viteTsconfigPaths()],
+  plugins: [
+    react(),
+    viteTsconfigPaths(),
+    {
+      name: 'transform-index-plugin',
+      transformIndexHtml(html: string) {
+        // Remove Google Analytics code if VITE_GOOGLE_ANALYTICS is set to 'false'
+        if (process.env.VITE_GOOGLE_ANALYTICS?.trim() === 'false') {
+          return html.replace(/<!-- GOOGLE_ANALYTICS_START -->[\s\S]*?<!-- GOOGLE_ANALYTICS_END -->/, '');
+        }
+      },
+    },
+  ],
+  resolve: {
+    alias: [
+      {
+        // Remove Google Analytics code if VITE_GOOGLE_ANALYTICS is set to 'false'
+        // Handles both formats of import statements used in this project
+        find: /\.?\.\/util\/analytics/, replacement: process.env.VITE_GOOGLE_ANALYTICS?.trim() === 'false'
+          ? resolve(__dirname, 'src/util/analytics_noop.ts')
+          : resolve(__dirname, 'src/util/analytics.ts')
+      },
+    ],
+  },
   server: {
     // this ensures that the browser opens upon server start
     open: true,


### PR DESCRIPTION
This is my attempt at addressing issue #232.

With a new optional environment variable `VITE_GOOGLE_ANALYTICS`, Google Analytics can be removed at build time.

Additional documentation included.

Tested on Windows 11 with `set VITE_GOOGLE_ANALYTICS=false && npm run build`.  Confirmed that `dist/index.html` doesn't reference the external `gtag` JavaScript library and that `dist/assets/index-********.js` doesn't reference the `gtag()` function.