### PR TITLE
Fix initialization of `selection` in App

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -391,7 +391,7 @@ export function App() {
         setState(
           loadMoreFromWikitree ? AppState.LOADING_MORE : AppState.SHOWING_CHART,
         );
-        updateDisplay(args.selection!);
+        updateDisplay(getSelection(data!.chartData, args.selection));
         if (loadMoreFromWikitree) {
           try {
             const data = await loadWikiTree(args.selection!.id, intl);


### PR DESCRIPTION
I believe this fixes #209.

Tested with `npm start` - confirmed that there are no console errors with `Cannot read properties of undefined (reading 'id')` when the browser back button is used to go from a second selected person back to the initial (default) person.

It would be great if someone else could test this as well - CC @czifumasa