### PR TITLE
Show _RUFNAME as a decorated part within GIVN

### DIFF
--- a/src/sidepanel/details/details.tsx
+++ b/src/sidepanel/details/details.tsx
@@ -191,12 +191,19 @@ function noteDetails(noteEntryReference: GedcomEntry, gedcom: GedcomData) {
 
 function nameDetails(entry: GedcomEntry) {
   const prefix = entry.tree.find((entry) => entry.tag === 'NPFX')?.data;
-  const given = entry.tree.find((entry) => entry.tag === 'GIVN')?.data;
-  const rufname = entry.tree.find((entry) => entry.tag === '_RUFNAME')?.data;
+  let given = entry.tree.find((entry) => entry.tag === 'GIVN')?.data;
+  let rufname = entry.tree.find((entry) => entry.tag === '_RUFNAME')?.data;
   const nickname = entry.tree.find((entry) => entry.tag === 'NICK')?.data;
   const surnamePrefix = entry.tree.find((entry) => entry.tag === 'SPFX')?.data;
   const surname = entry.tree.find((entry) => entry.tag === 'SURN')?.data;
   const suffix = entry.tree.find((entry) => entry.tag === 'NSFX')?.data;
+
+  // If _RUFNAME is included in GIVN, then replace this part in GIVN with this part in quotation marks,
+  // so that this name is not shown twice.
+  if (given && rufname && given.includes(rufname)) {
+    given = given.replace(rufname, `"${rufname}"`);
+    rufname = undefined;
+  }
 
   const fullNameParts = [
     prefix,


### PR DESCRIPTION
Currently function `nameDetails` simply concatenates various tags to build the full name. The tags `_RUFNAME` and `NICK` get some decoration.

Example: _Johannes Karl "Johannes" (Hannes) Buchholz_

Well, the name in `_RUFNAME` is a part of the given names in `GIVN`. Therefore, I suggest not to repeat the name but show it decorated within the given name.

Result for the example: _"Johannes" Karl (Hannes) Buchholz_

Special case: If the name in `_RUFNAME` is not part of the the given names in `GIVN`, then keep showing is as before.

Suggestion:
```
  // If _RUFNAME is included in GIVN, then replace this part in GIVN with this part in quotation marks,
  // so that this name is not shown twice.
  if (given && rufname && given.includes(rufname)) {
    given = given.replace(rufname, `"${rufname}"`);
    rufname = undefined;
  }
```

Limitation (as before): function `nameDetails` is only used on the details pane, but not in the graph.

References:
https://wiki.genealogy.net/Name_in_Gedcom
https://wiki.genealogy.net/GEDCOM/NAME-Tag#Vereinbarung_zu_Rufnamen