### PR TITLE
View details for different persons without rebuilding the tree

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -224,6 +224,8 @@ export function App() {
   const [data, setData] = useState<TopolaData>();
   /** Selected individual. */
   const [selection, setSelection] = useState<IndiInfo>();
+  /** Selected individual which should be displayed in the details pane. */
+  const [detailIndi, setDetailIndi] = useState<string>();
   /** Error to display. */
   const [error, setError] = useState<string>();
   /** Whether the side panel is shown. */
@@ -257,6 +259,7 @@ export function App() {
       selection!.generation !== newSelection.generation
     ) {
       setSelection(newSelection);
+      setDetailIndi(newSelection.id);
     }
   }
 
@@ -380,6 +383,7 @@ export function App() {
         // Set state from URL parameters.
         setSourceSpec(args.sourceSpec);
         setSelection(args.selection);
+        setDetailIndi(args.selection?.id);
         setStandalone(args.standalone);
         setShowWikiTreeMenus(args.showWikiTreeMenus);
         setChartType(args.chartType);
@@ -414,6 +418,7 @@ export function App() {
             const newSelection = getSelection(data.chartData, args.selection);
             setData(data);
             setSelection(newSelection);
+            setDetailIndi(newSelection.id);
             setState(AppState.SHOWING_CHART);
           } catch (error: any) {
             setState(AppState.SHOWING_CHART);
@@ -455,6 +460,13 @@ export function App() {
       indi: selection.id,
       gen: selection.generation,
     });
+  }
+  /**
+   * Called when the user shift+clicks an individual box in the chart.
+   * Shows the individual in the details pane.
+   */
+  function onDetailSelection(selection: IndiInfo) {
+    setDetailIndi(selection.id);
   }
 
   function onPrint() {
@@ -524,6 +536,7 @@ export function App() {
         selection={selection}
         chartType={chartType}
         onSelection={onSelection}
+        onDetailSelection={onDetailSelection}
         freezeAnimation={freezeAnimation}
         colors={config.color}
         hideIds={config.id}
@@ -550,7 +563,7 @@ export function App() {
             <SidebarPushable>
               <SidePanel
                 data={data!}
-                selectedIndiId={updatedSelection.id}
+                selectedIndiId={detailIndi || updatedSelection.id}
                 config={config}
                 expanded={showSidePanel}
                 onToggle={onToggleSidePanel}

--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -314,6 +314,7 @@ export interface ChartProps {
   selection: IndiInfo;
   chartType: ChartType;
   onSelection: (indiInfo: IndiInfo) => void;
+  onDetailSelection: (indiInfo: IndiInfo) => void;
   freezeAnimation?: boolean;
   colors?: ChartColors;
   hideIds?: Ids;
@@ -370,7 +371,16 @@ class ChartWrapper {
         chartType: getChartType(props.chartType),
         renderer: getRendererType(props.chartType),
         svgSelector: '#chart',
-        indiCallback: (info) => props.onSelection(info),
+        indiCallback: (info) => { // ths is called when an individual is selected in the chart
+            if (info.modifiers?.shiftKey) {
+              // If the shift key is pressed, we just update the details tab without changing the selection in the chart. 
+              // This allows users to quickly view details of multiple individuals without losing their place in the chart.
+              props.onDetailSelection(info)
+            } else {
+              // If the shift key is not pressed, we update the selection in the chart as usual.
+              props.onSelection(info)
+            }
+        },
         colors: chartColors.get(props.colors!),
         animate: true,
         updateSvgSize: false,
@@ -474,7 +484,11 @@ export function Chart(props: ChartProps) {
       const resetPosition =
         props.chartType !== prevProps?.chartType ||
         props.data !== prevProps.data ||
-        props.selection !== prevProps.selection;
+        // This does not work as the objects are always different instances. 
+        //props.selection !== prevProps.selection; 
+        // Therefore, compare id and generation instead.
+        props.selection.id !== prevProps.selection.id ||
+        props.selection.generation !== prevProps.selection.generation; 
       chartWrapper.current.renderChart(props, intl, {
         initialRender,
         resetPosition,


### PR DESCRIPTION
Hi PeWu,

here is the suggestion for solving Issue #269 using **Shift-Click** to show just the details of an individual without updating the chart. The solution is remarkable simple - I start loving the beauty of React!
As you can see, I followed your suggestion and just added a new React state and called the corresponding set function accordingly. 
Edit: I just see, that your suggestion used the name `onFocus`. Should I rename the name which I had used?

At first there was a small glitch: after showing the new detail data, the chart always reposititiond on the main person. I solved that with the change at line 487 in chart.tsx. (I guess I should remove the comment with another commit.)

I'm not sure if the update of `package.json` shoud be part of this pull request - so far I skipped it: 
```
 "dependencies": {
    "topola": "^3.10.1",
```

I didn't run any test in combination with an older version of topola, however, I believe that the related statement is robust even when running with an older version of topola: 
`if (info.modifiers?.shiftKey)`

Where should I add a piece of documentation?

Should I try to update the DonatsoChart as well? (It's easy to catch the Shift-Click event in function `onCardClick`, however, so far I cannot prevent that the chart zooms out as well.)

Greeting
Frank