### PR TITLE
Display search on mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -178,10 +178,6 @@ div.zoom {
   text-transform: uppercase;
 }
 
-.ui.sub.header, .ui.list {
-  margin-left: 20px;
-}
-
 .limit-height {
   height: 300px;
   overflow-y: scroll;
@@ -339,6 +335,14 @@ div.zoom {
   white-space: pre;
 }
 
+@media (max-width: 450px) {
+  /* Hide the title from the top bar when the viewport is too small to display
+     it alongside the search box. */
+  .topbar--title {
+    display: none;
+  }
+}
+
 @media (max-width: 767px) {
   #sidebar {
     background-color: #fff;
@@ -384,5 +388,16 @@ div.zoom {
 
   #content #sidebar.very.thin ~ .pusher {
     width: 100%;
+  }
+
+  /* Push the search box to the right on small screens. */
+  .ui.search {
+    margin-left: auto;
+    margin-right: 1em;
+  }
+
+  .ui.search>.results {
+    left: initial;
+    right: 0;
   }
 }

--- a/src/menu/top_bar.tsx
+++ b/src/menu/top_bar.tsx
@@ -224,7 +224,7 @@ export function TopBar(props: Props) {
     }
 
     switch (screenSize) {
-      case ScreenSize.LARGE: {
+      case ScreenSize.LARGE:
         // Show dropdown if chart is shown, otherwise show individual menu
         // items.
         const menus = props.showingChart ? (
@@ -251,7 +251,6 @@ export function TopBar(props: Props) {
           </>
         );
         return menus;
-      }
 
       case ScreenSize.SMALL:
         return (
@@ -311,7 +310,16 @@ export function TopBar(props: Props) {
             </Dropdown.Item>
           </Dropdown.Menu>
         </Dropdown>
-        {props.standalone ? <Link to="/">{title()}</Link> : title()}
+        <div className="topbar--title">
+          {props.standalone ? <Link to="/">{title()}</Link> : title()}
+        </div>
+        {props.showingChart && (
+          <SearchBar
+            data={props.data!}
+            onSelection={props.eventHandlers.onSelection}
+            {...props}
+          />
+        )}
       </>
     );
   }

--- a/src/menu/top_bar.tsx
+++ b/src/menu/top_bar.tsx
@@ -227,7 +227,7 @@ export function TopBar(props: Props) {
       case ScreenSize.LARGE:
         // Show dropdown if chart is shown, otherwise show individual menu
         // items.
-        const menus = props.showingChart ? (
+        return props.showingChart ? (
           <Dropdown
             trigger={
               <div>
@@ -250,7 +250,6 @@ export function TopBar(props: Props) {
             <WikiTreeMenu menuType={MenuType.Menu} {...props} />
           </>
         );
-        return menus;
 
       case ScreenSize.SMALL:
         return (


### PR DESCRIPTION
The changes aim to make search accessible on the mobile version of the tree viewer. The search box is displayed on the right hand side of the top bar on screens with a viewport of less than 768 pixels.

When the viewport width is no longer sufficient to display the 'Topola Genealogy' title and the search box, the former is hidden.

This solution ensures that search, a key component of the system, is usable regardless of the size of a user's device.

Closes #166.

### Preview on Narrow Mobile Screen
<img width="654" height="612" alt="image" src="https://github.com/user-attachments/assets/ef3fe04f-2550-40e2-8c68-efe7d8ec63cf" />

### Preview on Wide Mobile Screen
<img width="777" height="586" alt="image" src="https://github.com/user-attachments/assets/e9314de1-10a8-4737-8b15-1acd0b4b2d91" />