### PR TITLE
Fix for File Selector not being able to select .ged files on mobile devices

### DIFF
--- a/src/menu/upload_menu.tsx
+++ b/src/menu/upload_menu.tsx
@@ -84,7 +84,7 @@ export function UploadMenu(props: Props) {
       <input
         className="hidden"
         type="file"
-        accept=".ged,.gdz,.gedzip,.zip,.webp,image/*"
+        accept=".ged,.gdz,.gedzip,.zip,.jpg,.jpeg,.png,.gif,.webp"
         id="fileInput"
         multiple
         onChange={handleUpload}

--- a/src/menu/upload_menu.tsx
+++ b/src/menu/upload_menu.tsx
@@ -84,7 +84,7 @@ export function UploadMenu(props: Props) {
       <input
         className="hidden"
         type="file"
-        accept=".ged,.gdz,.gedzip,.zip,.jpg,.jpeg,.png,.gif,.webp"
+        accept=".ged,.gdz,.gedzip,.zip"
         id="fileInput"
         multiple
         onChange={handleUpload}

--- a/src/menu/upload_menu.tsx
+++ b/src/menu/upload_menu.tsx
@@ -84,7 +84,6 @@ export function UploadMenu(props: Props) {
       <input
         className="hidden"
         type="file"
-        accept=".ged,.gdz,.gedzip,.zip"
         id="fileInput"
         multiple
         onChange={handleUpload}

--- a/src/menu/upload_menu.tsx
+++ b/src/menu/upload_menu.tsx
@@ -13,6 +13,14 @@ interface Props {
   menuType: MenuType;
 }
 
+/**
+ * On touch devices (iOS, Android) the browser's file picker ignores unknown
+ * extensions like .ged and may restrict selection to photos when image types
+ * are listed. Omitting the `accept` attribute lets the OS file browser show
+ * all files without filtering.
+ */
+const isTouchDevice = navigator.maxTouchPoints > 0;
+
 /** Displays and handles the "Open file" menu. */
 export function UploadMenu(props: Props) {
   const navigate = useNavigate();
@@ -84,6 +92,11 @@ export function UploadMenu(props: Props) {
       <input
         className="hidden"
         type="file"
+        accept={
+          isTouchDevice
+            ? undefined
+            : '.ged,.gdz,.gedzip,.zip,.jpg,.jpeg,.png,.gif,.webp'
+        }
         id="fileInput"
         multiple
         onChange={handleUpload}

--- a/src/menu/upload_menu.tsx
+++ b/src/menu/upload_menu.tsx
@@ -19,7 +19,7 @@ interface Props {
  * are listed. Omitting the `accept` attribute lets the OS file browser show
  * all files without filtering.
  */
-const isTouchDevice = navigator.maxTouchPoints > 0;
+const isMobileDevice = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
 /** Displays and handles the "Open file" menu. */
 export function UploadMenu(props: Props) {
@@ -93,7 +93,7 @@ export function UploadMenu(props: Props) {
         className="hidden"
         type="file"
         accept={
-          isTouchDevice
+          isMobileDevice
             ? undefined
             : '.ged,.gdz,.gedzip,.zip,.jpg,.jpeg,.png,.gif,.webp'
         }


### PR DESCRIPTION
Hey there,
I had a small issue with opening .ged files on iOS devices. It seems that .ged is not a registered file type that iOS recognizes. Even though we include the .ged extension in the `accept` filter, the iOS file browser shows them as grayed out and prevents us from selecting them. I was wondering if it would be acceptable to omit the `accept` filter on mobile devices so that the user can select any file.