### PR TITLE
isImageFile rejects extensionless image URLs

### DIFF
--- a/src/util/gedcom_util.spec.ts
+++ b/src/util/gedcom_util.spec.ts
@@ -215,6 +215,17 @@ describe('Media Resolution and Utilities', () => {
       expect(isImageFile('test.webp?a=1&b=2#h')).toBe(true);
       expect(isImageFile('test.pdf?img=test.jpg')).toBe(false);
     });
+
+    it('treats blob: and data:image URLs as images', () => {
+      expect(isImageFile('blob:https://example.org/0-1-2-3')).toBe(true);
+      expect(isImageFile('data:image/avif;base64,AAAA')).toBe(true);
+      expect(isImageFile('data:image/png;base64,iVBORw0KGgo=')).toBe(true);
+    });
+
+    it('does not treat non-image extensionless URLs as images', () => {
+      expect(isImageFile('data:application/pdf;base64,AAAA')).toBe(false);
+      expect(isImageFile('https://example.org/photo')).toBe(false);
+    });
   });
 
   describe('isBrowserLoadable()', () => {

--- a/src/util/gedcom_util.ts
+++ b/src/util/gedcom_util.ts
@@ -207,11 +207,26 @@ export function normalizeGedcom(gedcom: JsonGedcomData): JsonGedcomData {
 
 const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp'];
 
-/** Returns true if the given file name has a known image extension. */
+/**
+ * Returns true if the given file reference points to an image.
+ *
+ * Recognizes two kinds of reference:
+ * - a name/URL ending in a known image extension (e.g. `photo.jpg`), and
+ * - an extensionless but inherently browser-renderable image reference: a
+ *   `blob:` object URL or a `data:image/...` URI.
+ *
+ * The second case matters because `isBrowserLoadable` already accepts these
+ * schemes, but they carry no path extension. Without this, `filterImage` drops
+ * any OBJE/FILE whose value is an object or data URL (e.g. images injected by an
+ * embedding host), even though the browser could render them.
+ */
 export function isImageFile(fileName: string): boolean {
-  const cleanName = fileName.split(/[?#]/)[0];
-  const lowerName = cleanName.toLowerCase();
-  return IMAGE_EXTENSIONS.some((ext) => lowerName.endsWith(ext));
+  const lowerName = fileName.toLowerCase();
+  if (lowerName.startsWith('blob:') || lowerName.startsWith('data:image/')) {
+    return true;
+  }
+  const cleanName = lowerName.split(/[?#]/)[0];
+  return IMAGE_EXTENSIONS.some((ext) => cleanName.endsWith(ext));
 }
 
 /**


### PR DESCRIPTION
isImageFile() classifies references by file extension only. isBrowserLoadable() accepts blob: and data: URLs, but those have no extension. In filterImage(), those images pass the loadable check, fail the image check, and are dropped from the chart. They are only survived when the URLs come through the uploaded-images map (gdz path), which is why inlined blob:/data: URLs render nowhere.

Treat blob: and data:image/ references as images. data: is matched narrowly so non-image data URIs (data:application/pdf) stay non-images. blob: is accepted unconditionally because a blob URL's MIME type isn't derivable from the string.