### PR TITLE
Recognize `blob:` and `data:image` URLs as images

### DIFF
--- a/src/util/gedcom_util.spec.ts
+++ b/src/util/gedcom_util.spec.ts
@@ -215,6 +215,17 @@ describe('Media Resolution and Utilities', () => {
       expect(isImageFile('test.webp?a=1&b=2#h')).toBe(true);
       expect(isImageFile('test.pdf?img=test.jpg')).toBe(false);
     });
+
+    it('treats blob: and data:image URLs as images', () => {
+      expect(isImageFile('blob:https://example.org/0-1-2-3')).toBe(true);
+      expect(isImageFile('data:image/png;base64,iVBORw0KGgo=')).toBe(true);
+      expect(isImageFile('data:image/avif;base64,AAAA')).toBe(true);
+    });
+
+    it('does not treat non-image extensionless URLs as images', () => {
+      expect(isImageFile('data:application/pdf;base64,AAAA')).toBe(false);
+      expect(isImageFile('https://example.org/photo')).toBe(false);
+    });
   });
 
   describe('isBrowserLoadable()', () => {

--- a/src/util/gedcom_util.ts
+++ b/src/util/gedcom_util.ts
@@ -207,11 +207,25 @@ export function normalizeGedcom(gedcom: JsonGedcomData): JsonGedcomData {
 
 const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp'];
 
-/** Returns true if the given file name has a known image extension. */
+/**
+ * Returns true if the given file reference points to an image: a name/URL with
+ * a known image extension, or an extensionless but inherently browser-renderable
+ * `blob:` object URL or `data:image/...` URI. The latter two carry no path
+ * extension but are already accepted by `isBrowserLoadable`, so without this
+ * `filterImage` would drop them. A `blob:` URL's type is not derivable from the
+ * string, so it is accepted unconditionally; `data:` is required to be an image.
+ */
 export function isImageFile(fileName: string): boolean {
-  const cleanName = fileName.split(/[?#]/)[0];
-  const lowerName = cleanName.toLowerCase();
-  return IMAGE_EXTENSIONS.some((ext) => lowerName.endsWith(ext));
+  // Anchored tests read only the scheme, so an inlined data: payload (which can
+  // be multi-megabyte) is never scanned or copied.
+  if (/^blob:/i.test(fileName)) {
+    return true;
+  }
+  if (/^data:/i.test(fileName)) {
+    return /^data:image\//i.test(fileName);
+  }
+  const cleanName = fileName.split(/[?#]/)[0].toLowerCase();
+  return IMAGE_EXTENSIONS.some((ext) => cleanName.endsWith(ext));
 }
 
 /**


### PR DESCRIPTION
## Recognize `blob:` and `data:image` URLs as images

### Problem
`isBrowserLoadable()` accepts `blob:` object URLs and `data:` URIs, but `isImageFile()` classified files purely by path extension. These schemes have no extension, so in `filterImage()` a directly-referenced `blob:`/`data:` URL passed the loadable check, failed the extension check, and was dropped from the chart. (It only survived if it happened to be remapped through the uploaded-images map, where `resolvedUrl !== normalizedUrl` short-circuits the predicate.)

### Why it matters
In embedded mode the parent posts a GEDCOM string into the iframe (`EmbeddedDataSource`). A host that prefetches person media and inlines it as `blob:` or `data:image/...` URLs in the OBJE/FILE values hits this: the images are browser-renderable but never shown.

### Fix
`isImageFile()` now also recognizes:
- `blob:` — accepted unconditionally, since a blob URL's MIME type isn't derivable from the string.
- `data:image/` — matched narrowly, so non-image data URIs (e.g. `data:application/pdf`) stay classified as non-images.

The scheme is checked with `^`-anchored regexes, which read only the prefix — an inlined `data:` payload (potentially multi-megabyte base64) is never scanned or lowercased. `isImageFile()` also backs the primary-photo predicates in `findFileEntry()`, so this keeps those consistent for embedded media.

### Tests
Added cases to `gedcom_util.spec.ts` covering `blob:`/`data:image` recognition and confirming `data:application/pdf` and bare extensionless URLs remain non-images.