### PR TITLE
Don't cache embedded GEDCOM in sessionStorage

### DIFF
--- a/src/datasource/embedded.ts
+++ b/src/datasource/embedded.ts
@@ -61,7 +61,15 @@ export class EmbeddedDataSource implements DataSource<EmbeddedSourceSpec> {
       try {
         const embeddedHash = 'embedded';
         storeGedcom(embeddedHash, gedcom, new Map());
-        const data = await loadGedcom(embeddedHash, onProgress);
+        // Embedded data is volatile: the parent re-posts a fresh GEDCOM on every
+        // load (and a page reload re-runs the ready/parent_ready handshake, so
+        // the parent re-sends). That GEDCOM may inline object URLs (blob:/data:)
+        // that die with the previous document. Persisting it to sessionStorage
+        // under the constant 'embedded' key would return dead URLs on the next
+        // load, so opt out of the session cache for embedded data.
+        const data = await loadGedcom(embeddedHash, onProgress, {
+          useSessionCache: false,
+        });
         const software = getSoftware(data.gedcom.head);
         analyticsEvent('embedded_file_loaded', {
           event_label: software,

--- a/src/datasource/load_data.ts
+++ b/src/datasource/load_data.ts
@@ -35,9 +35,10 @@ async function prepareData(
   cacheId: string,
   images?: Map<string, string>,
   onProgress?: (status: string) => void,
+  useSessionCache = true,
 ): Promise<TopolaData> {
   const data = await convertGedcom(gedcom, images || new Map(), onProgress);
-  if (!images || images.size === 0) {
+  if (useSessionCache && (!images || images.size === 0)) {
     if (gedcom.length <= SESSION_CACHE_GEDCOM_LIMIT) {
       const dataToSerialize = {...data};
       delete dataToSerialize.images;
@@ -184,14 +185,18 @@ export async function loadFromUrl(
 export async function loadGedcom(
   hash: string,
   onProgress?: (status: string) => void,
+  options?: {useSessionCache?: boolean},
 ): Promise<TopolaData> {
-  try {
-    const cachedData = sessionStorage.getItem(hash);
-    if (cachedData) {
-      return JSON.parse(cachedData);
+  const useSessionCache = options?.useSessionCache ?? true;
+  if (useSessionCache) {
+    try {
+      const cachedData = sessionStorage.getItem(hash);
+      if (cachedData) {
+        return JSON.parse(cachedData);
+      }
+    } catch (e) {
+      console.warn('Failed to load data from session storage: ' + e);
     }
-  } catch (e) {
-    console.warn('Failed to load data from session storage: ' + e);
   }
   // Retrieve from the in-memory store (survives within-tab navigation even
   // when the GEDCOM is too large for history.pushState or sessionStorage).
@@ -203,7 +208,13 @@ export async function loadGedcom(
     );
   }
   try {
-    return await prepareData(stored.gedcom, hash, stored.images, onProgress);
+    return await prepareData(
+      stored.gedcom,
+      hash,
+      stored.images,
+      onProgress,
+      useSessionCache,
+    );
   } catch (error) {
     revokeObjectUrls(stored.images);
     throw error;

--- a/src/datasource/load_data_store.spec.ts
+++ b/src/datasource/load_data_store.spec.ts
@@ -1,6 +1,7 @@
-import {describe, expect, it} from '@jest/globals';
+import {beforeEach, describe, expect, it} from '@jest/globals';
 import {storeGedcom} from './gedcom_store';
 import {loadGedcom} from './load_data';
+import {mockSessionStorage} from './test_helpers';
 
 // Minimal GEDCOM with 1 individual and 1 family so convertGedcom succeeds.
 const MINIMAL_GEDCOM = [
@@ -41,5 +42,33 @@ describe('loadGedcom()', () => {
       'Step 3/4: sorting & normalizing…',
       'Step 4/4: indexing records…',
     ]);
+  });
+});
+
+describe('loadGedcom() session cache', () => {
+  let sessionStorageMock: {[key: string]: string};
+
+  beforeEach(() => {
+    sessionStorageMock = mockSessionStorage();
+  });
+
+  it('caches prepared data in sessionStorage by default', async () => {
+    const hash = 'cache-default-hash';
+    storeGedcom(hash, MINIMAL_GEDCOM, new Map());
+    await loadGedcom(hash);
+    expect(sessionStorageMock[hash]).toBeDefined();
+  });
+
+  it('ignores and preserves the cache when useSessionCache is false', async () => {
+    const hash = 'cache-disabled-hash';
+    sessionStorageMock[hash] = JSON.stringify({stale: true});
+    storeGedcom(hash, MINIMAL_GEDCOM, new Map());
+
+    const data = await loadGedcom(hash, undefined, {useSessionCache: false});
+
+    // Returned from the in-memory store, not the stale cache.
+    expect(data.chartData.indis).toHaveLength(1);
+    // The stale entry is neither served nor overwritten with fresh data.
+    expect(sessionStorageMock[hash]).toBe(JSON.stringify({stale: true}));
   });
 });


### PR DESCRIPTION
## Don't cache embedded GEDCOM in sessionStorage

### Summary
Embedded mode receives a fresh GEDCOM from the parent window on every load, so persisting it to `sessionStorage` under a constant key only ever serves a stale copy. This adds a `useSessionCache` opt-out to `loadGedcom()`/`prepareData()` and has the embedded data source opt out, so embedded data is never read from or written to the session cache.

### Background
The in-memory store added in #296 already covers within-tab navigation, and the `ready`/`parent_ready` handshake means a page reload re-runs and the parent re-sends the GEDCOM. For embedded mode the `sessionStorage` layer therefore adds nothing — it's redundant with the handshake and the in-memory store.

It's also actively wrong when the GEDCOM references resources tied to the parent document. Embedded payloads can inline object URLs (`blob:`/`data:`) that become invalid once the previous document is gone. `loadGedcom()` caches the prepared data under the constant key `embedded`, and `prepareData()`'s existing guard only skips the write when a non-empty uploaded-images map is present — embedded mode passes an empty map (URLs are inlined in the GEDCOM text), so the guard didn't apply. On the next load the cached copy was served with dead object URLs and images broke until a hard refresh.

### Change
- `loadGedcom()` / `prepareData()` take an optional `useSessionCache` (default `true`), gating both the read and the write.
- `EmbeddedDataSource` calls `loadGedcom('embedded', onProgress, { useSessionCache: false })`.

No behavior change for any other data source — uploaded files still use the default (cache on). The in-memory store continues to serve within-tab navigation; a reload repopulates it via the handshake.

### Testing
- New tests in `load_data_store.spec.ts`: caching happens by default, and with `useSessionCache: false` a stale entry is neither served nor overwritten.
- `npm run lint`, `tsc`, and `npm test` (jest) all pass locally.

### How I hit this
I run Topola Viewer behind a reverse proxy that also serves Gramps Web on the same origin; the GEDCOM is delivered to the embedded viewer via the Gramps Web API. After a reload, images failed to load until a hard refresh — the stale `embedded` cache entry was the cause.